### PR TITLE
Conditionally render header and footer based on proxy status

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,11 @@
 import type { Metadata } from 'next';
-// import { Inter } from 'next/font/google'; // Inter is imported but not used
 import './globals.css';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 import { Toaster } from '@/components/ui/toaster';
 import { Geist } from 'next/font/google';
 import { Geist_Mono } from 'next/font/google';
-
+import { headers } from 'next/headers';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -18,26 +17,27 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 });
 
-
 export const metadata: Metadata = {
   title: 'F3 Codex - Exicon & Lexicon',
   description: 'The official Exicon and Lexicon for F3 Nation.',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const isProxied = (await headers()).has('X-F3-Worker-Proxy');
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
         suppressHydrationWarning={true}
       >
-        <Header />
+        {!isProxied && <Header />}
         <main className="flex-grow">{children}</main>
-        <Footer />
+        {!isProxied && <Footer />}
         <Toaster />
       </body>
     </html>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ export function Footer() {
     <footer className="border-t py-8">
       <div className="container text-center text-sm text-muted-foreground">
         <p>&copy; {new Date().getFullYear()} F3 Nation. All rights reserved.</p>
-        <p>F3 Codex - Fitness, Fellowship, Faith.</p>
+        <p>F3 Codex - Fitness, Fellowship, Faith&reg; .</p>
       </div>
     </footer>
   );


### PR DESCRIPTION
This pull request introduces conditional rendering for the header and footer components based on the presence of a specific proxy header. If the request is proxied, the header and footer will not be displayed. Additionally, a minor update to the footer text has been made to include a registered trademark symbol. This enhancement improves the user experience by ensuring that unnecessary elements are not shown in proxied requests.