### PR TITLE
Add submit entry button to Exicon and Lexicon client pages

### DIFF
--- a/src/app/exicon/ExiconClientPageContent.tsx
+++ b/src/app/exicon/ExiconClientPageContent.tsx
@@ -3,13 +3,14 @@
 import { useState, useMemo } from 'react';
 import { SearchBar } from '@/components/shared/SearchBar';
 import { Button } from '@/components/ui/button';
-import { Download, Dumbbell } from 'lucide-react';
+import { Download, Dumbbell, PencilLine } from 'lucide-react';
 import { EntryGrid } from '@/components/shared/EntryGrid';
 import type { ExiconEntry, Tag, FilterLogic, AnyEntry } from '@/lib/types';
 import { exportToCSV } from '@/lib/utils';
 import { TagFilter } from '@/components/exicon/TagFilter';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Filter } from 'lucide-react';
+import Link from 'next/link';
 
 interface ExiconClientPageContentProps {
   initialEntries: (ExiconEntry & {
@@ -112,13 +113,23 @@ export const ExiconClientPageContent = ({ initialEntries, allTags }: ExiconClien
 
         <div className="mb-6 flex flex-col sm:flex-row gap-4 items-center">
           <SearchBar searchTerm={searchTerm} onSearchChange={setSearchTerm} placeholder="Search exercises by name or alias..." />
-          <Button
-            onClick={() => exportToCSV(filteredEntries.filter((entry): entry is ExiconEntry => entry.type === 'exicon'))}
-            variant="outline"
-            className="w-full sm:w-auto"
-          >
-            <Download className="mr-2 h-4 w-4" /> Export CSV
-          </Button>
+          <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+            <Link href="/submit-entry" passHref>
+              <Button
+                variant="outline"
+                className="w-full sm:w-auto"
+              >
+                <PencilLine className="mr-2 h-4 w-4" /> Submit Entry
+              </Button>
+            </Link>
+            <Button
+              onClick={() => exportToCSV(filteredEntries.filter((entry): entry is ExiconEntry => entry.type === 'exicon'))}
+              variant="outline"
+              className="w-full sm:w-auto"
+            >
+              <Download className="mr-2 h-4 w-4" /> Export CSV
+            </Button>
+          </div>
         </div>
 
         <EntryGrid entries={filteredEntries} />

--- a/src/app/lexicon/LexiconClientPageContent.tsx
+++ b/src/app/lexicon/LexiconClientPageContent.tsx
@@ -4,10 +4,11 @@ import { useState, useMemo } from 'react';
 import type { AnyEntry, LexiconEntry } from '@/lib/types';
 import { SearchBar } from '@/components/shared/SearchBar';
 import { Button } from '@/components/ui/button';
-import { Download, BookText } from 'lucide-react';
+import { Download, BookText, PencilLine } from 'lucide-react';
 import { EntryGrid } from '@/components/shared/EntryGrid';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Filter } from 'lucide-react';
+import Link from 'next/link';
 
 // A helper function to export to CSV
 // This function is robust and handles the potential for different alias types
@@ -122,13 +123,23 @@ export const LexiconClientPageContent = ({ initialEntries }: LexiconClientPageCo
 
         <div className="mb-6 flex flex-col sm:flex-row gap-4 items-center">
           <SearchBar searchTerm={searchTerm} onSearchChange={setSearchTerm} placeholder="Search Lexicon..." />
-          <Button
-            onClick={() => exportToCSV(filteredEntries.filter((entry): entry is LexiconEntry => entry.type === 'lexicon'))}
-            variant="outline"
-            className="w-full sm:w-auto"
-          >
-            <Download className="mr-2 h-4 w-4" /> Export CSV
-          </Button>
+          <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
+            <Link href="/submit-entry" passHref>
+              <Button
+                variant="outline"
+                className="w-full sm:w-auto"
+              >
+                <PencilLine className="mr-2 h-4 w-4" /> Submit Entry
+              </Button>
+            </Link>
+            <Button
+              onClick={() => exportToCSV(filteredEntries.filter((entry): entry is LexiconEntry => entry.type === 'lexicon'))}
+              variant="outline"
+              className="w-full sm:w-auto"
+            >
+              <Download className="mr-2 h-4 w-4" /> Export CSV
+            </Button>
+          </div>
         </div>
         <EntryGrid entries={filteredEntries} />
       </main>


### PR DESCRIPTION
This PR introduces a "Submit Entry" button to both the Exicon and Lexicon client pages, allowing users to easily navigate to the entry submission form. The button is styled consistently with existing UI elements and is positioned alongside the "Export CSV" button for improved user experience. Additionally, the necessary icons have been imported to enhance the visual representation of the buttons.