### PR TITLE
Remove header and footer rendering based on proxy status

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,8 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
 import { Toaster } from '@/components/ui/toaster';
 import { Geist } from 'next/font/google';
 import { Geist_Mono } from 'next/font/google';
-import { headers } from 'next/headers';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -27,7 +24,6 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const isProxied = (await headers()).has('X-F3-Worker-Proxy');
 
   return (
     <html lang="en" suppressHydrationWarning>
@@ -35,9 +31,7 @@ export default async function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased flex flex-col min-h-screen`}
         suppressHydrationWarning={true}
       >
-        {!isProxied && <Header />}
         <main className="flex-grow">{children}</main>
-        {!isProxied && <Footer />}
         <Toaster />
       </body>
     </html>


### PR DESCRIPTION
This PR removes the conditional rendering of the header and footer components based on the proxy status. As a result, the header and footer will no longer be displayed conditionally, simplifying the layout component.