### PR TITLE
Add searchParams support for entryId in metadata generation and redirection

### DIFF
--- a/src/app/exicon/[entryId]/page.tsx
+++ b/src/app/exicon/[entryId]/page.tsx
@@ -12,9 +12,10 @@ import CopyLinkButton from '@/components/shared/CopyLinkButton';
 import { SuggestEditsButton } from '@/components/shared/SuggestEditsButton';
 import { CopyEntryUrlButton } from '@/components/shared/CopyEntryUrlButton';
 
-export async function generateMetadata({ params }: { params: Promise<{ entryId: string }> }): Promise<Metadata> {
+export async function generateMetadata({ params, searchParams }: { params: Promise<{ entryId: string }>, searchParams: Promise<{ [key: string]: string | string[] | undefined }> }): Promise<Metadata> {
   const { entryId: rawEntryId } = await params;
-  const entryId = decodeURIComponent(rawEntryId);
+  const searchParamsResolved = await searchParams;
+  const entryId = searchParamsResolved.entryId ? decodeURIComponent(String(searchParamsResolved.entryId)) : decodeURIComponent(rawEntryId);
   const entry = await getEntryByIdFromDatabase(entryId);
 
   if (!entry || entry.type !== 'exicon') {
@@ -57,9 +58,10 @@ export async function generateMetadata({ params }: { params: Promise<{ entryId: 
   };
 }
 
-export default async function ExiconEntryPage({ params }: { params: Promise<{ entryId: string }> }) {
+export default async function ExiconEntryPage({ params, searchParams }: { params: Promise<{ entryId: string }>, searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
     const { entryId: rawEntryId } = await params;
-    const entryId = decodeURIComponent(rawEntryId);
+    const searchParamsResolved = await searchParams;
+    const entryId = searchParamsResolved.entryId ? decodeURIComponent(String(searchParamsResolved.entryId)) : decodeURIComponent(rawEntryId);
 
     const entry = await getEntryByIdFromDatabase(entryId);
 

--- a/src/app/exicon/page.tsx
+++ b/src/app/exicon/page.tsx
@@ -54,7 +54,14 @@ function normalizeAliases(aliases: unknown, entryId: string): { id: string; name
     : [];
 }
 
-export default async function ExiconPage() {
+export default async function ExiconPage({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+  const searchParamsResolved = await searchParams;
+
+  if (searchParamsResolved.entryId) {
+    const entryId = String(searchParamsResolved.entryId);
+    const { redirect } = await import('next/navigation');
+    redirect(`/exicon/${encodeURIComponent(entryId)}`);
+  }
 
   let allEntries: AnyEntry[] = [];
   let enrichedEntries: ExiconEntry[] = [];

--- a/src/app/lexicon/[entryId]/page.tsx
+++ b/src/app/lexicon/[entryId]/page.tsx
@@ -9,9 +9,10 @@ import { getEntryByIdFromDatabase } from '@/lib/api';
 import { SuggestEditsButton } from '@/components/shared/SuggestEditsButton';
 import { CopyEntryUrlButton } from '@/components/shared/CopyEntryUrlButton';
 
-export async function generateMetadata({ params }: { params: Promise<{ entryId: string }> }): Promise<Metadata> {
+export async function generateMetadata({ params, searchParams }: { params: Promise<{ entryId: string }>, searchParams: Promise<{ [key: string]: string | string[] | undefined }> }): Promise<Metadata> {
   const { entryId: rawEntryId } = await params;
-  const entryId = decodeURIComponent(rawEntryId);
+  const searchParamsResolved = await searchParams;
+  const entryId = searchParamsResolved.entryId ? decodeURIComponent(String(searchParamsResolved.entryId)) : decodeURIComponent(rawEntryId);
   const entry = await getEntryByIdFromDatabase(entryId);
 
   if (!entry || entry.type !== 'lexicon') {
@@ -53,9 +54,10 @@ export async function generateMetadata({ params }: { params: Promise<{ entryId: 
   };
 }
 
-export default async function LexiconEntryPage({ params }: { params: Promise<{ entryId: string }> }) {
+export default async function LexiconEntryPage({ params, searchParams }: { params: Promise<{ entryId: string }>, searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
     const { entryId: rawEntryId } = await params;
-    const entryId = decodeURIComponent(rawEntryId);
+    const searchParamsResolved = await searchParams;
+    const entryId = searchParamsResolved.entryId ? decodeURIComponent(String(searchParamsResolved.entryId)) : decodeURIComponent(rawEntryId);
 
     const entry = await getEntryByIdFromDatabase(entryId);
 

--- a/src/app/lexicon/page.tsx
+++ b/src/app/lexicon/page.tsx
@@ -37,7 +37,14 @@ function normalizeAliases(aliases: unknown, entryId: string): { id: string; name
     : [];
 }
 
-export default async function LexiconPage() {
+export default async function LexiconPage({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+  const searchParamsResolved = await searchParams;
+
+  if (searchParamsResolved.entryId) {
+    const entryId = String(searchParamsResolved.entryId);
+    const { redirect } = await import('next/navigation');
+    redirect(`/lexicon/${encodeURIComponent(entryId)}`);
+  }
   let allEntries: AnyEntry[] = [];
   let enrichedEntries: LexiconEntry[] = [];
   let allAvailableTags: Tag[] = [];

--- a/src/components/shared/CopyEntryUrlButton.tsx
+++ b/src/components/shared/CopyEntryUrlButton.tsx
@@ -16,7 +16,7 @@ export function CopyEntryUrlButton({ entry }: CopyEntryUrlButtonProps) {
 
   const handleCopy = async () => {
     const encodedId = encodeURIComponent(entry.id);
-    const url = `https://f3nation.com/${entry.type === 'exicon' ? 'exicon' : 'lexicon'}/${encodedId}`;
+    const url = `https://f3nation.com/${entry.type === 'exicon' ? 'exicon' : 'lexicon'}?entryId=${encodedId}`;
 
     try {
       await navigator.clipboard.writeText(url);

--- a/src/components/shared/EntryCard.tsx
+++ b/src/components/shared/EntryCard.tsx
@@ -107,7 +107,7 @@ const renderDescriptionWithMentions = (
     parts.push(
       <HoverCard key={`mention-${mention.index}-${mention.entry.id}`} openDelay={200} closeDelay={100}>
         <HoverCardTrigger asChild>
-          <Link href={`/${mention.entry.type === 'exicon' ? 'exicon' : 'lexicon'}/${mention.entry.id}`}>
+          <Link href={`/${mention.entry.type === 'exicon' ? 'exicon' : 'lexicon'}?entryId=${mention.entry.id}`}>
             <span className={`${colorClass} underline hover:no-underline cursor-pointer font-medium transition-colors duration-200`}>
               {mention.text}
             </span>
@@ -158,7 +158,7 @@ const renderDescriptionWithMentions = (
 
             <div className="pt-2 border-t">
               <Link
-                href={mention.entry.type === 'exicon' ? `/exicon/${mention.entry.id}` : `/lexicon/${mention.entry.id}`}
+                href={mention.entry.type === 'exicon' ? `/exicon?entryId=${mention.entry.id}` : `/lexicon?entryId=${mention.entry.id}`}
                 className="text-xs text-blue-500 hover:text-blue-600 hover:underline"
               >
                 View full entry →
@@ -228,7 +228,7 @@ export function EntryCard({ entry }: EntryCardProps) {
   const handleCopyEntryContent = async (event: React.MouseEvent) => {
     event.stopPropagation();
     const encodedId = encodeURIComponent(entry.id);
-    const url = `https://f3nation.com/${entry.type === 'exicon' ? 'exicon' : 'lexicon'}/${encodedId}`;
+    const url = `https://f3nation.com/${entry.type === 'exicon' ? 'exicon' : 'lexicon'}?entryId=${encodedId}`;
     try {
       await navigator.clipboard.writeText(url);
       toast({ title: `${entry.name} URL Copied!`, description: "The link has been copied to your clipboard." });


### PR DESCRIPTION
This pull request introduces support for `searchParams` in the metadata generation and redirection processes for both the Exicon and Lexicon pages. The changes allow the application to handle `entryId` from the search parameters, enhancing the flexibility of URL handling. Additionally, the `CopyEntryUrlButton` and `EntryCard` components have been updated to include `entryId` in the generated URLs, ensuring consistency across the application.