### PR TITLE
Dynamic metadata generation for Exicon and Lexicon pages

### DIFF
--- a/src/app/lexicon/page.tsx
+++ b/src/app/lexicon/page.tsx
@@ -7,10 +7,56 @@ import type { AnyEntry, LexiconEntry, Tag } from '@/lib/types';
 
 
 
-export const metadata = {
-  title: 'F3 Lexicon - F3 Codex',
-  description: 'Explore F3 terminology in the Lexicon.',
-};
+export async function generateMetadata({ searchParams }: { searchParams: Promise<{ [key: string]: string | string[] | undefined }> }) {
+  const searchParamsResolved = await searchParams;
+
+  if (searchParamsResolved.entryId) {
+    const entryId = String(searchParamsResolved.entryId);
+
+    try {
+      const entry = await getEntryByIdFromDatabase(entryId);
+
+      if (entry && entry.type === 'lexicon') {
+        const title = `${entry.name} - F3 Lexicon`;
+        const description = entry.description || `Learn about ${entry.name} in the F3 Lexicon.`;
+        const url = `https://f3nation.com/lexicon?entryId=${entryId}`;
+
+        return {
+          title,
+          description,
+          openGraph: {
+            title,
+            description,
+            url,
+            siteName: 'F3 Nation Codex',
+            type: 'article',
+            images: [
+              {
+                url: '/og-lexicon.png',
+                width: 1200,
+                height: 630,
+                alt: `${entry.name} - F3 Lexicon Term`,
+              },
+            ],
+          },
+          twitter: {
+            card: 'summary_large_image',
+            title,
+            description,
+            images: ['/og-lexicon.png'],
+          },
+        };
+      }
+    } catch (error) {
+      console.error('Failed to generate metadata for entry:', error);
+    }
+  }
+
+  return {
+    title: 'F3 Lexicon - F3 Codex',
+    description: 'Explore F3 terminology in the Lexicon.',
+  };
+}
 
 const getUniqueMentionedIds = (entries: AnyEntry[]): string[] => {
   const allMentionedIds = entries.flatMap(entry => entry.mentionedEntries || []);


### PR DESCRIPTION
This pull request implements dynamic metadata generation for the Exicon and Lexicon pages. The `generateMetadata` function retrieves entry details based on the provided `entryId` from the search parameters, allowing for customized titles and descriptions. If an entry is found, it generates Open Graph and Twitter card metadata for better sharing capabilities. If no entry is found, it defaults to a predefined title and description. This enhancement improves the SEO and social media presence of the pages.