### PR TITLE
Update submission links to include entry type in query parameters

### DIFF
--- a/src/app/exicon/ExiconClientPageContent.tsx
+++ b/src/app/exicon/ExiconClientPageContent.tsx
@@ -114,7 +114,7 @@ export const ExiconClientPageContent = ({ initialEntries, allTags }: ExiconClien
         <div className="mb-6 flex flex-col sm:flex-row gap-4 items-center">
           <SearchBar searchTerm={searchTerm} onSearchChange={setSearchTerm} placeholder="Search exercises by name or alias..." />
           <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
-            <Link href="/submit" passHref>
+            <Link href="/submit?type=exicon" passHref>
               <Button
                 variant="outline"
                 className="w-full sm:w-auto"

--- a/src/app/lexicon/LexiconClientPageContent.tsx
+++ b/src/app/lexicon/LexiconClientPageContent.tsx
@@ -124,7 +124,7 @@ export const LexiconClientPageContent = ({ initialEntries }: LexiconClientPageCo
         <div className="mb-6 flex flex-col sm:flex-row gap-4 items-center">
           <SearchBar searchTerm={searchTerm} onSearchChange={setSearchTerm} placeholder="Search Lexicon..." />
           <div className="flex flex-col sm:flex-row gap-4 w-full sm:w-auto">
-            <Link href="/submit" passHref>
+            <Link href="/submit?type=lexicon" passHref>
               <Button
                 variant="outline"
                 className="w-full sm:w-auto"

--- a/src/components/submission/SubmissionForm.tsx
+++ b/src/components/submission/SubmissionForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -15,10 +16,15 @@ import { MentionTextArea } from '@/components/shared/MentionTextArea';
 
 export function SubmissionForm() {
   const { toast } = useToast();
+  const searchParams = useSearchParams();
+
+  // Get the default entry type from URL parameter, fallback to 'exicon'
+  const defaultEntryType = searchParams.get('type') === 'lexicon' ? 'lexicon' : 'exicon';
+
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [aliases, setAliases] = useState('');
-  const [entryType, setEntryType] = useState<'exicon' | 'lexicon'>('exicon');
+  const [entryType, setEntryType] = useState<'exicon' | 'lexicon'>(defaultEntryType);
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [videoLink, setVideoLink] = useState('');
   const [submitterName, setSubmitterName] = useState('');
@@ -55,7 +61,7 @@ export function SubmissionForm() {
     setName('');
     setDescription('');
     setAliases('');
-    setEntryType('exicon');
+    setEntryType(defaultEntryType);
     setSelectedTagIds([]);
     setVideoLink('');
     setSubmitterName('');


### PR DESCRIPTION
This pull request modifies the submission links in the Exicon and Lexicon client pages to include the entry type as a query parameter. Additionally, the `SubmissionForm` component has been updated to set the default entry type based on the URL parameter, allowing for a more dynamic submission process. This change enhances the user experience by ensuring that the correct entry type is pre-selected when users navigate to the submission form.