### PR TITLE
adding missing comments in admin panel

### DIFF
--- a/src/app/admin/AdminPanel.tsx
+++ b/src/app/admin/AdminPanel.tsx
@@ -1479,10 +1479,12 @@ export default function AdminPanel() {
                     </p>
                   )}
                   <div className="space-y-2">
-                    <h4 className="text-lg font-semibold">Comments</h4>
+                    <h4 className="text-lg font-semibold">
+                      Reason for Changes / Comments
+                    </h4>
                     <p className="text-sm text-muted-foreground">
                       {(viewingSubmission.data as EditEntrySuggestionData)
-                        .changes.comments || "No comments provided."}
+                        .comments || "No comments provided."}
                     </p>
                   </div>
                 </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,7 +79,6 @@ export interface EditEntrySuggestionData {
     videoLink?: string;
     mentionedEntries?: string[];
     entryType?: "exicon" | "lexicon";
-    comments?: string;
   };
   comments?: string;
 }


### PR DESCRIPTION
  1. AdminPanel.tsx:1487 - Changed from .changes.comments to .comments so it correctly accesses the comments field at the root level
  2. AdminPanel.tsx:1483 - Updated the heading to "Reason for Changes / Comments" to match the label used in the submission form
  3. types.ts:74-82 - Removed the incorrect comments field from inside the changes object to prevent future confusion

  The field will now display correctly when reviewing edit submissions for approval